### PR TITLE
[BUG] back broken when on first fragment

### DIFF
--- a/cocoa-touch/src/main/java/com/hummingbird/cocoatouch/uikit/UINavigationController.java
+++ b/cocoa-touch/src/main/java/com/hummingbird/cocoatouch/uikit/UINavigationController.java
@@ -136,9 +136,13 @@ public class UINavigationController extends AppCompatActivity
         UIFragment fragment = viewController.view.fragment();
         fragment.transition = animated?fragment.transition:new NoneTransition();
         fragmentTransaction
-                .add(containerID(), fragment)
-                .addToBackStack(viewController.getClass().getName())
-                .commit();
+                .add(containerID(), fragment);
+
+        if (this.pushViewControllers.count() > 1) {
+            fragmentTransaction.addToBackStack(viewController.getClass().getName());
+        }
+
+        fragmentTransaction.commit();
     }
     private UIViewController lastViewController(NSArray<UIViewController> array)
     {


### PR DESCRIPTION
When the user clicks on the back button while navigating on first fragment, the app goes to a blank screen before really quitting. This PR fixes this by not adding the initial fragment to the backstack.

Reference here: https://developer.android.com/training/basics/fragments/fragment-ui.html
